### PR TITLE
Basic styling for the module

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "tests"
   ],
   "devDependencies": {
-    "angularjs": "1.3.x"
+    "angularjs": "1.3.x",
+    "normalize.css": "~3.0.2"
   }
 }

--- a/examples/example.css
+++ b/examples/example.css
@@ -1,0 +1,39 @@
+/*
+|--------------------------------------------------------------------------
+| example.css
+|--------------------------------------------------------------------------
+|
+| These styles exist for the sole purpose of making the demo prettier and
+| are not required for the basic look and behaviour of the module.
+|
+*/
+
+body {
+  padding: 1em;
+  background: #039be5;
+  font: normal 14px/1 Helvetica Neue;
+}
+
+main {
+  padding: 1.618em 1em;
+  background: #fff;
+  border-radius: 3px;
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24),
+              0 1.5px 6px rgba(0, 0, 0, 0.12);
+
+  display: flex;
+  display: -webkit-flex;
+}
+
+*:first-child {
+  margin-top: 0;
+}
+
+h1 {
+  color: #fff;
+  font-weight: 300;
+}
+
+.mw-typeahead__column {
+  margin-right: 1.618em;
+}

--- a/examples/mw-typeahead.css
+++ b/examples/mw-typeahead.css
@@ -1,0 +1,77 @@
+/*
+|--------------------------------------------------------------------------
+| mw-typeahead.css
+|--------------------------------------------------------------------------
+|
+| These are the default styles for mw-typeahead.
+|
+| [1] Since people might want to use different left, right, or margin-top
+|     values depending on input field styling, the ul should have its own
+|     class name for easy overriding.
+|
+| [2] A z-index of 1 is enough, assuming that surrounding elements never
+|     have (higher) z-indexes. Which they shouldn't.
+|
+| [3] Quick fix for blur event hiding element before click is registered.
+|     This should probably be fixed with js instead.
+|
+| [4] Don't allow multi-row list objects. There should probably be an
+|     option to toggle this.
+|
+| [5] I dislike when these dropdowns have selectable text. Since this
+|     property isn't part of the W3C specification it must be
+|     vendor-prefixed and without a prefix-free version of the property.
+|
+*/
+
+.mw-typeahead__wrap {
+  position: relative;
+}
+
+.mw-typeahead__wrap ul {
+  margin: 0;
+  padding: .5em 0;
+  list-style: none;
+
+  position: absolute; /* [1] */
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 1; /* [2] */
+
+  background: #fff;
+  border-radius: 0 0 3px 3px;
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.23),
+              0 3px 12px rgba(0, 0, 0, 0.16);
+}
+
+.mw-typeahead__wrap ul:active {
+  display: block !important; /* [3] */
+}
+
+.mw-typeahead__item {
+  display: block;
+  background: #fff;
+  cursor: pointer;
+  padding: .5em .75em;
+
+  overflow: hidden; /* [4] */
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  -webkit-user-select: none; /* [5] */
+     -moz-user-select: none;
+      -ms-user-select: none;
+}
+
+.mw-typeahead__item:hover:not(.mw-typeahead--active) {
+  background: #f4f4f4;
+}
+
+.mw-typeahead__item:hover:active {
+  background: #b3e5fc;
+}
+
+.mw-typeahead--active {
+  background: #b3e5fc;
+}

--- a/examples/names.js
+++ b/examples/names.js
@@ -145,6 +145,7 @@ var names = [
   { firstName: "Nella", lastName: "Stockard" },
   { firstName: "Nelle", lastName: "Runnels" },
   { firstName: "Nickolas", lastName: "Loney" },
+  { firstName: "Nils", lastName: "Kaspersson" },
   { firstName: "Nova", lastName: "Dufour" },
   { firstName: "Nydia", lastName: "Baca" },
   { firstName: "Ocie", lastName: "Belton" },

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -1,35 +1,39 @@
 <!doctype html>
 <html>
 	<head>
+		<link rel="stylesheet" href="../bower_components/normalize.css/normalize.css">
+		<link rel="stylesheet" href="example.css">
+		<link rel="stylesheet" href="mw-typeahead.css">
 
 		<script src="../bower_components/angularjs/angular.js"></script>
 		<script src="../typeahead.js"></script>
 		<script src="names.js"></script>
 		<script src="simple.js"></script>
-
-		<style>
-			.mw-typeahead__active {
-				font-weight: bold;
-			}
-		</style>
 	</head>
 
 	<body ng-app="simple" ng-controller="SimpleCtrl">
-		<h3>Typeahead:</h3>
+		<h1>Simple example</h1>
 
-		<mw-typeahead ng-model="selectedItem"
-		              case-sensitive="false"
-		              item-query="queryNames(prefix)"
-		              max-items="10"
-		              item-text="item.firstName + ' ' + item.lastName">
-			<li>{{::item.firstName + ' ' + item.lastName}}</li>
-		</mw-typeahead>
+		<main>
+			<div class="mw-typeahead__column">
+				<h3>Typeahead:</h3>
+				<mw-typeahead ng-model="selectedItem"
+											case-sensitive="false"
+											item-query="queryNames(prefix)"
+											max-items="10"
+											class="mw-typeahead__wrap"
+											item-text="item.firstName + ' ' + item.lastName">
+					<li class="mw-typeahead__item">{{::item.firstName + ' ' + item.lastName}}</li>
+				</mw-typeahead>
+			</div>
 
-		<h4>Selected item:</h4>
-
-		<div>
-			Firstname: {{ selectedItem.firstName }}<br />
-			Lastname: {{ selectedItem.lastName }}
-		</div>
+			<div class="mw-typeahead__column">
+				<h3>Selected item:</h3>
+				<div>
+					Firstname: {{ selectedItem.firstName }}<br />
+					Lastname: {{ selectedItem.lastName }}
+				</div>
+			</div>
+		</main>
 	</body>
 </html>

--- a/typeahead.js
+++ b/typeahead.js
@@ -1,7 +1,7 @@
 (function(angular) {
   "use strict";
 
-  var ACTIVE_CLASS   = "mw-typeahead__active";
+  var ACTIVE_CLASS   = "mw-typeahead--active";
   var KEY_ARROW_DOWN = 40;
   var KEY_ARROW_UP   = 38;
   var KEY_ENTER      = 13;


### PR DESCRIPTION
Further suggestions:
- Add default class names to the generated HTML (and probably to the list items as well). Users should not have to override two- or three levels deep selectors.
- Clicks on list items still trigger the blur event before the click event. There's a quick fix with CSS included, but it'd be better to fix it with javascript.
